### PR TITLE
The changes made are fairly simple, but they help in rolling back the transactions in case of error. Please let me know if you have any question. I am reachable on suyogbarve@gmail.com

### DIFF
--- a/src/main/java/com/btoddb/flume/sinks/cassandra/CassandraSinkRepository.java
+++ b/src/main/java/com/btoddb/flume/sinks/cassandra/CassandraSinkRepository.java
@@ -19,6 +19,7 @@ package com.btoddb.flume.sinks.cassandra;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -109,7 +110,7 @@ public class CassandraSinkRepository {
 
     }
 
-    public void saveToCassandra(List<Event> eventList) {
+    public void saveToCassandra(List<Event> eventList) throws InterruptedException, ExecutionException{
         CassandraJob job = new CassandraJob(keyspace, workExecutor);
         for (Event event : eventList) {
             FlumeLogEvent flumeLog = new FlumeLogEvent(event);

--- a/src/main/java/com/btoddb/flume/sinks/cassandra/CassandraWriteWork.java
+++ b/src/main/java/com/btoddb/flume/sinks/cassandra/CassandraWriteWork.java
@@ -18,17 +18,12 @@ package com.btoddb.flume.sinks.cassandra;
 
 import java.nio.ByteBuffer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import me.prettyprint.cassandra.serializers.ByteBufferSerializer;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.factory.HFactory;
 import me.prettyprint.hector.api.mutation.Mutator;
 
 public class CassandraWriteWork implements Runnable {
-    private static Logger logger = LoggerFactory.getLogger(CassandraWriteWork.class);
-    
     Mutator<ByteBuffer> mutator;
     private CassandraWorkStatus callback;
 
@@ -39,12 +34,7 @@ public class CassandraWriteWork implements Runnable {
     }
 
     public void run() {
-        try {
-            mutator.execute();
-        }
-        catch (Throwable e) {
-            logger.error("exception while executing mutator", e);
-        }
+    	mutator.execute();
         callback.finished(this);
     }
 


### PR DESCRIPTION
Propagate the exception in CassandraWriteWork to let CassandraSink
rollback the transaction in case of exceptions
